### PR TITLE
Fix/image issues

### DIFF
--- a/di_website/templates/includes/heroes/hero.html
+++ b/di_website/templates/includes/heroes/hero.html
@@ -1,6 +1,6 @@
 {% load wagtailimages_tags wagtailcore_tags responsive%}
 
-{% responsiveimage page.hero_image fill-1200x778 srcset=global.hero_srcs as image %}
+{% responsiveimage page.hero_image fill-1600x780-c100 srcset=global.hero_srcs as image %}
 <section class="hero {% if image %}hero--image{% endif %}">
     {% if image %}
         <div class="hero__image" style="background-image: url('{{ image.url }}');"></div>

--- a/di_website/templates/ourteam/our_team_page.html
+++ b/di_website/templates/ourteam/our_team_page.html
@@ -52,13 +52,15 @@
         <div class="row row--narrow">
             <div class="l-4up">
               {% for profile in profiles %}
-                {% image profile.image max-260x260 as img %}
                 <div class="l-4up__col">
                     <a href="{% pageurl profile %}">
                         <div class="profile">
+                          {% if profile.image %}
+                            {% image profile.image max-260x260 as img %}
                             <div class="profile__media">
                                 <img src="{{img.url}}" alt="alt">
                             </div>
+                          {% endif %}
                             <div class="profile__caption">
                                 <h3 class="profile__title">{{profile.name|default_if_none:""}}</h3>
                                 <p class="profile__meta">{{profile.position.name|default_if_none:""}}</p>
@@ -66,6 +68,7 @@
                         </div>
                     </a>
                 </div>
+
               {% endfor %}
             </div>
         </div>


### PR DESCRIPTION
In the event of a mis-loading image, prevents profile pictures from bleeding over:
![image](https://user-images.githubusercontent.com/2836840/61488374-10869000-a976-11e9-921f-a885a0e05240.png)

Also added `-c100` to the hero so focal points will be more impactful. Might also ask Fffunction about setting min height? I think the majority of the issue is from the differing amounts of space according to the hero text.