### PR TITLE
Add fallback image to related pages for general page

### DIFF
--- a/di_website/templates/tags/cards/other_pages.html
+++ b/di_website/templates/tags/cards/other_pages.html
@@ -9,7 +9,11 @@
         <a href="{% pageurl page %}" class="card">
           {% if page.hero_image %}
             {% image page.hero_image fill-400x250 as image %}
-            <div class="card__media" style="background-image: url('{{ image.url }}');"></div>
+            {% if image.url != '/media/not-found' %}
+              <div class="card__media" style="background-image: url('{{ image.url }}');"></div>
+            {% else %}
+              <div class="card__media" style="background-image: url({% static 'img/fallback-image.jpg' %})"></div>
+            {% endif %}
           {% else %}
             <div class="card__media" style="background-image: url({% static 'img/fallback-image.jpg' %})"></div>
           {% endif %}

--- a/di_website/templates/tags/cards/other_pages.html
+++ b/di_website/templates/tags/cards/other_pages.html
@@ -5,23 +5,19 @@
 <div class="row row--narrow">
     <h2 class="section__heading">{{ heading }}</h2>
     <div class="l-4up">
-        {% for page in other_pages %}
+      {% for page in other_pages %}
+        <a href="{% pageurl page %}" class="card">
+          {% if page.hero_image %}
             {% image page.hero_image fill-400x250 as image %}
-            <a href="{% pageurl page %}" class="card">
-                {% if image %}
-                  <div class="card__media" style="background-image: url('{% if page.hero_image %}{{ image.url }}{% endif %}');">
-                  </div>
-                {% else %}
-                  <div class="card__media" style="background-image: url({% static 'img/fallback-image.jpg' %})">
-                  </div>
-                {% endif %}
-
-                <div class="card__body">
-                    <h3 class="card__title"><span>{{ page.title }}</span></h3>
-                </div>
-            </a>
-        {% endfor %}
-
+            <div class="card__media" style="background-image: url('{{ image.url }}');"></div>
+          {% else %}
+            <div class="card__media" style="background-image: url({% static 'img/fallback-image.jpg' %})"></div>
+          {% endif %}
+          <div class="card__body">
+            <h3 class="card__title"><span>{{ page.title }}</span></h3>
+          </div>
+        </a>
+      {% endfor %}
     </div>
 </div>
 

--- a/di_website/templates/tags/cards/other_pages.html
+++ b/di_website/templates/tags/cards/other_pages.html
@@ -1,4 +1,4 @@
-{% load wagtailimages_tags wagtailcore_tags %}
+{% load wagtailimages_tags wagtailcore_tags static %}
 
 {% if other_pages %}
 
@@ -8,9 +8,14 @@
         {% for page in other_pages %}
             {% image page.hero_image fill-400x250 as image %}
             <a href="{% pageurl page %}" class="card">
-                <div class="card__media"
-                    style="background-image: url('{% if page.hero_image %}{{ image.url }}{% endif %}');">
-                </div>
+                {% if image %}
+                  <div class="card__media" style="background-image: url('{% if page.hero_image %}{{ image.url }}{% endif %}');">
+                  </div>
+                {% else %}
+                  <div class="card__media" style="background-image: url({% static 'img/fallback-image.jpg' %})">
+                  </div>
+                {% endif %}
+
                 <div class="card__body">
                     <h3 class="card__title"><span>{{ page.title }}</span></h3>
                 </div>


### PR DESCRIPTION
This is a fix for issue [328](https://github.com/devinit/DIwebsite-redesign/issues/328) adding a default image to related pages section of general page.