### PR TITLE
Add padding for 3 digit footnotes

### DIFF
--- a/di_website/static/css/di_website.css
+++ b/di_website/static/css/di_website.css
@@ -83,6 +83,6 @@
   stroke: transparent !important;
 }
 
-.three-digit-footnote {
+.footnotes__item {
   padding-left: 10px;
 }

--- a/di_website/static/css/di_website.css
+++ b/di_website/static/css/di_website.css
@@ -82,3 +82,7 @@
 .hovertext path {
   stroke: transparent !important;
 }
+
+.three-digit-footnote {
+  padding-left: 10px;
+}

--- a/di_website/templates/publications/footnotes.html
+++ b/di_website/templates/publications/footnotes.html
@@ -7,7 +7,11 @@
                 <h2 class="heading type-l type-l--trailer">Notes</h2>
                 {% for item in page.footnotes_list %}
                 <ul class="footnotes__list">
+                {% if forloop.counter <= 99 %}
                     <li class="footnotes__item">
+                {% else %}
+                    <li class="footnotes__item three-digit-footnote">
+                {% endif %}
                         <span class="heading type-m type-m--trailer footnotes__sub">{{ forloop.counter }}</span>
                         <a id="{{ item.footnote_id }}"></a>
                         <p class="footnotes__text">{{ item.text | urlize }}</p>

--- a/di_website/templates/publications/footnotes.html
+++ b/di_website/templates/publications/footnotes.html
@@ -7,11 +7,7 @@
                 <h2 class="heading type-l type-l--trailer">Notes</h2>
                 {% for item in page.footnotes_list %}
                 <ul class="footnotes__list">
-                {% if forloop.counter <= 99 %}
-                    <li class="footnotes__item">
-                {% else %}
-                    <li class="footnotes__item three-digit-footnote">
-                {% endif %}
+                  <li class="footnotes__item">
                         <span class="heading type-m type-m--trailer footnotes__sub">{{ forloop.counter }}</span>
                         <a id="{{ item.footnote_id }}"></a>
                         <p class="footnotes__text">{{ item.text | urlize }}</p>


### PR DESCRIPTION
This affects footnotes with 3 digits, that is > 99. Testing with dokku deployment seems ideal to avoid having to create 100 footnotes on your local environment. I copied `wysiwyg` content from the [devinit.org](https://devinit.org/admin/pages/2138/edit/) website to test on `localhost`.
[Issue details](https://github.com/devinit/DIwebsite-redesign/issues/886#issue-687971345)