### PR TITLE
Remove link when author page isn't live

### DIFF
--- a/di_website/templates/includes/partials/multi-authors.html
+++ b/di_website/templates/includes/partials/multi-authors.html
@@ -11,17 +11,21 @@
       {% endif %}
     </h3>
     <p class="m-authors__copy">
-      {% if first_author %}
+      {% if first_author and first_author.live %}
         <a href="{% pageurl first_author %}?referrer=author">
           {{ first_author.specific.name }}
         </a>{% if authors|length > 0 %}, {% endif %}
+      {% elif first_author %}
+          {{ first_author.specific.name }}{% if authors|length > 0 %}, {% endif %}
       {% endif %}
       {% for author in authors %}
         {% if author.value %}
-          {% if author.block_type == 'internal_author' %}
+          {% if author.block_type == 'internal_author' and author.value.live %}
             <a href="{% pageurl author.value %}?referrer=author">
               {{ author.value.specific.name }}
             </a>{% if not forloop.last %}, {% endif %}
+          {% elif author.block_type == 'internal_author' %}
+              {{ author.value.specific.name }}{% if not forloop.last %}, {% endif %}
           {% else %}
             {% if author.value.page %}
               <a href="{{ author.value.page }}">{{ author.value.name }}</a>{% if not forloop.last %}, {% endif %}


### PR DESCRIPTION
For https://github.com/devinit/DIwebsite-redesign/issues/911

Removes hyperlink of draft internal author pages: 
![image](https://user-images.githubusercontent.com/2836840/94685274-30923d00-02f7-11eb-95be-8753ecea95a0.png)

But is not capable of reducing the length of the author object in the event it's deleted: 
![image](https://user-images.githubusercontent.com/2836840/94685480-76e79c00-02f7-11eb-8133-984b9d335eb7.png)

