### PR TITLE
Update elasticsearch to 7.16.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - consul
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.2.4
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.16.2
     environment:
       - discovery.type=single-node
       - "ES_JAVA_OPTS=-Xms512m -Xmx1g"


### PR DESCRIPTION
Updates elasticsearch to latest version to take care of Log4j vulnerability

### Notes:
Before deploying on the live environment, please follow the following instructions;

1. Manually edit the docker-compose.yml file and replace 6.2.4 with 6.8.2

2. Run the following commands

`docker-compose up elasticsearch`
`docker-compose exec -T elasticsearch curl -XGET 'http://localhost:9200'` (this shows you the version currently running, if it's not 6.8.2 at this step, then something is wrong)
`docker-compose exec -T green python manage.py update_index` (update the indexes from wagtail)

3. Manually edit the docker-compose.yml file and replace 6.8.2 with 7.16.2

Rerun the commands in 2 above
