### PR TITLE
Command to replace links

### DIFF
--- a/di_website/common/management/commands/fixlinks.py
+++ b/di_website/common/management/commands/fixlinks.py
@@ -1,0 +1,35 @@
+"""Management command that replaces old hashbang links."""
+
+import json
+from django.core.management.base import BaseCommand
+from di_website.publications.models import LegacyPublicationPage
+
+
+class Command(BaseCommand):
+    """Management command that fixed aidtransparency links."""
+
+    help = 'Replace links given a JSON file.'
+
+    def add_arguments(self, parser):
+        """Add custom command arguments."""
+        parser.add_argument('json_file', nargs='+', type=str)
+
+    def handle(self, *args, **options):
+        """Implement the command handler."""
+        with open(options['json_file'][0]) as json_file:
+            json_data = json.load(json_file)
+
+        all_pages = LegacyPublicationPage.objects.live()
+
+        for page in all_pages:
+            for replacement in json_data:
+                old_link = '"' + replacement["OldLink"] + '"'
+                new_link = '"' + replacement["NewLink"] + '"'
+                old_content = page.raw_content
+                if old_link in old_content:
+                    self.stdout.write(self.style.SUCCESS("Replacing old link in page: " + page.slug))
+                    new_content = old_content.replace(old_link, new_link)
+                    page.raw_content = new_content
+                    page.save()
+
+        self.stdout.write(self.style.SUCCESS("Done."))

--- a/replace_links.json
+++ b/replace_links.json
@@ -146,5 +146,37 @@
   {
     "OldLink": "http://devinit.org/#!/post/unbundling-aid",
     "NewLink": "https://devinit.org/data"
+  },
+  {
+    "OldLink": "http://devinit.org/#!/post/using-budget-data-to-improve-water-policy-in-nepal-2",
+    "NewLink": "http://devinit.org/wp-content/uploads/2015/05/CASE-STUDY-Using-budget-data-for-water-policy-Nepal-SHORT-2014-09.pdf"
+  },
+  {
+    "OldLink": "http://devinit.org/#!/post/transforming-data-into-useful-information-the-story-of-a-liberian-transparency-advocate",
+    "NewLink": "http://devinit.org/wp-content/uploads/2015/05/CASE-STUDY-Transforming-data-for-transparency-advocacy-Liberia-LONG-2014-12.pdf"
+  },
+  {
+    "OldLink": "http://devinit.org/#!/post/using-public-finance-data-to-monitor-sub-national-resource-allocation-in-kenya",
+    "NewLink": "https://devinit.org/resources/using-public-finance-data-to-monitor-sub-national-resource-allocation-in-kenya/"
+  },
+  {
+    "OldLink": "http://devinit.org/#!/post/using-project-data-to-improve-sexual-health-services-in-kenya",
+    "NewLink": "https://devinit.org/resources/using-project-data-to-improve-sexual-health-services-in-kenya/"
+  },
+  {
+    "OldLink": "http://devinit.org/#!/post/using-foreign-aid-data-to-improve-policy-making-2",
+    "NewLink": "https://devinit.org/resources/using-foreign-aid-data-to-improve-policy-making-2/"
+  },
+  {
+    "OldLink": "http://devinit.org/#!/post/opening-public-data-to-improve-government-transparency-in-nepal",
+    "NewLink": "https://devinit.org/resources/opening-public-data-to-improve-government-transparency-in-nepal/"
+  },
+  {
+    "OldLink": "http://devinit.org/#!/post/using-information-about-local-development-projects-to-empower-citizens",
+    "NewLink": "https://devinit.org/resources/using-information-about-local-development-projects-to-empower-citizens/"
+  },
+  {
+    "OldLink": "http://devinit.org/#!/post/using-citizen-generated-data-to-improve-school-performance-in-kenya",
+    "NewLink": "https://devinit.org/resources/using-citizen-generated-data-to-improve-school-performance-in-kenya/"
   }
 ]

--- a/replace_links.json
+++ b/replace_links.json
@@ -1,0 +1,150 @@
+[
+  {
+    "OldLink": "http://devinit.org/#!/about/meet-the-team/sophia-swithern",
+    "NewLink": "https://devinit.org/who-we-are/our-team/sophia-swithern-2/"
+  },
+  {
+    "OldLink": "http://devinit.org/#!/about/meet-the-team/rob-tew",
+    "NewLink": "https://devinit.org/who-we-are/our-team/rob-tew/"
+  },
+  {
+    "OldLink": "http://devinit.org/#!/about/meet-the-team/harpinder-collacott",
+    "NewLink": "https://devinit.org/who-we-are/our-team/harpinder-collacott/"
+  },
+  {
+    "OldLink": "http://devinit.org/#!/about/meet-the-team/daniel-coppard",
+    "NewLink": "https://devinit.org/who-we-are/our-team/daniel-coppard/"
+  },
+  {
+    "OldLink": "http://devinit.org/#!/about/meet-the-team/bill-anderson",
+    "NewLink": "https://devinit.org/who-we-are/our-team/bill-anderson/"
+  },
+  {
+    "OldLink": "http://devinit.org/#!/p20i",
+    "NewLink": "https://devinit.org/what-we-do/what-we-are-working-on/tracking-progress-poorest-people/"
+  },
+  {
+    "OldLink": "http://devinit.org/#!/page/p20i",
+    "NewLink": "https://devinit.org/what-we-do/what-we-are-working-on/tracking-progress-poorest-people/"
+  },
+  {
+    "OldLink": "http://devinit.org/#!/post/bristol-based-international-development-organisation-enters-landmark-three-year-partnership-with-the-foreign-ministry-of-the-republic-of-korea",
+    "NewLink": "https://devinit.org/what-we-do/news/bristol-based-international-development-organisation-enters-landmark-three-year-partnership-foreign-ministry-republic-korea/"
+  },
+  {
+    "OldLink": "http://devinit.org/#!/post/innovation-and-effectiveness-challenges-risks-and-opportunities-for-blended-finance",
+    "NewLink": "https://devinit.org/what-we-do/events/innovation-and-effectiveness-challenges-risks-and-opportunities-for-blended-finance/"
+  },
+  {
+    "OldLink": "http://devinit.org/#!/post/high-level-conference-on-the-data-revolution-in-africa-defining-the-next-steps-for-data-communities",
+    "NewLink": "https://devinit.org/what-we-do/events/high-level-conference-on-the-data-revolution-in-africa-defining-the-next-steps-for-data-communities/"
+  },
+  {
+    "OldLink": "http://devinit.org/#!/post/oda-loans-tracking-a-growing-source-of-development-financing",
+    "NewLink": "https://devinit.org/resources/oda-loans-tracking-a-growing-source-of-development-financing/"
+  },
+  {
+    "OldLink": "http://devinit.org/#!/post/investments-to-end-poverty-2015",
+    "NewLink": "https://devinit.org/resources/investments-to-end-poverty-2015/"
+  },
+  {
+    "OldLink": "http://devinit.org/#!/post/investments-in-peace-and-security",
+    "NewLink": "https://devinit.org/resources/investments-in-peace-and-security/"
+  },
+  {
+    "OldLink": "http://devinit.org/#!/post/humanitarian-evidence-systems-mapping-in-east-africa",
+    "NewLink": "https://devinit.org/resources/humanitarian-evidence-systems-mapping-in-east-africa/"
+  },
+  {
+    "OldLink": "http://devinit.org/#!/GHA2016",
+    "NewLink": "https://devinit.org/resources/global-humanitarian-assistance-report-2016/"
+  },
+  {
+    "OldLink": "http://devinit.org/#!/post/foreign-aid-and-stimulating-domestic-revenue-mobilisation-in-uganda-and-kenya-2",
+    "NewLink": "https://devinit.org/resources/foreign-aid-and-stimulating-domestic-revenue-mobilisation-in-uganda-and-kenya-2/"
+  },
+  {
+    "OldLink": "http://devinit.org/#!/post/blended-finance-understanding-its-potential",
+    "NewLink": "https://devinit.org/resources/blended-finance-understanding-its-potential/"
+  },
+  {
+    "OldLink": "http://devinit.org/#!/post/betterinformation",
+    "NewLink": "https://devinit.org/resources/betterinformation/"
+  },
+  {
+    "OldLink": "http://devinit.org/#!/uganda/kiryandongo",
+    "NewLink": "https://devinit.org/data/spotlight-uganda?t=uganda_poverty_and_vulnerability&i=spotlight_on_uganda_2017.uganda_poverty_headcount&y=2014&lc=UG.d421&ln=kiryandongo"
+  },
+  {
+    "OldLink": "http://devinit.org/#!/uganda/buvuma",
+    "NewLink": "https://devinit.org/data/spotlight-uganda?t=uganda_poverty_and_vulnerability&i=spotlight_on_uganda_2017.uganda_poverty_headcount&y=2014&lc=UG.d120&ln=buvuma"
+  },
+  {
+    "OldLink": "http://devinit.org/#!/country/uganda",
+    "NewLink": "https://devinit.org/data/spotlight-uganda"
+  },
+  {
+    "OldLink": "http://devinit.org/#!/spotlight-on-uganda",
+    "NewLink": "https://devinit.org/data/spotlight-uganda"
+  },
+  {
+    "OldLink": "http://devinit.org/#!/data",
+    "NewLink": "https://devinit.org/data/"
+  },
+  {
+    "OldLink": "http://devinit.org/#!/post/targeting-the-poorest-20-the-case-of-least-developed-countries",
+    "NewLink": "https://devinit.org/blog/targeting-the-poorest-20-the-case-of-least-developed-countries/"
+  },
+  {
+    "OldLink": "http://data.devinit.org/#!/country/",
+    "NewLink": ""
+  },
+  {
+    "OldLink": "http://data.devinit.org/#!/multilaterals",
+    "NewLink": ""
+  },
+  {
+    "OldLink": "http://devinit.org/#!/about/meet-the-team/charles-lwanga-ntale",
+    "NewLink": ""
+  },
+  {
+    "OldLink": "http://devinit.org/#!/about/meet-the-team/joni-hillman",
+    "NewLink": ""
+  },
+  {
+    "OldLink": "http://devinit.org/#!/about/meet-the-team/judith-randel",
+    "NewLink": ""
+  },
+  {
+    "OldLink": "http://devinit.org/#!/about/meet-the-team/tony-german",
+    "NewLink": ""
+  },
+  {
+    "OldLink": "http://devinit.org/#!/post/di-continues-role-as-technical-lead-for-iati",
+    "NewLink": ""
+  },
+  {
+    "OldLink": "http://devinit.org/#!/post/interoperable-data-uganda",
+    "NewLink": ""
+  },
+  {
+    "OldLink": "http://devinit.org/#!/post/joined-up-data-alliance-announcement",
+    "NewLink": ""
+  },
+  {
+    "OldLink": "http://devinit.org/#!/post/key-trends-in-humanitarian-financing-what-do-they-mean-for-future-resourcing-to-address-crises-risk-and-vulnerability",
+    "NewLink": ""
+  },
+  {
+    "OldLink": "http://devinit.org/#!/post/launch-of-the-development-data-hub-in-uganda",
+    "NewLink": ""
+  },
+  {
+    "OldLink": "http://devinit.org/#!/post/new-partnership-help-east-africans-access-use-understand-statistical-data-information",
+    "NewLink": ""
+  },
+  {
+    "OldLink": "http://devinit.org/#!/post/unbundling-aid",
+    "NewLink": ""
+  }
+]

--- a/replace_links.json
+++ b/replace_links.json
@@ -97,54 +97,54 @@
   },
   {
     "OldLink": "http://data.devinit.org/#!/country/",
-    "NewLink": ""
+    "NewLink": "https://devinit.org/data/"
   },
   {
     "OldLink": "http://data.devinit.org/#!/multilaterals",
-    "NewLink": ""
+    "NewLink": "https://devinit.org/data/"
   },
   {
     "OldLink": "http://devinit.org/#!/about/meet-the-team/charles-lwanga-ntale",
-    "NewLink": ""
+    "NewLink": "https://devinit.org/who-we-are/our-team/"
   },
   {
     "OldLink": "http://devinit.org/#!/about/meet-the-team/joni-hillman",
-    "NewLink": ""
+    "NewLink": "https://devinit.org/who-we-are/our-team/"
   },
   {
     "OldLink": "http://devinit.org/#!/about/meet-the-team/judith-randel",
-    "NewLink": ""
+    "NewLink": "https://devinit.org/who-we-are/our-team/"
   },
   {
     "OldLink": "http://devinit.org/#!/about/meet-the-team/tony-german",
-    "NewLink": ""
+    "NewLink": "https://devinit.org/who-we-are/our-team/"
   },
   {
     "OldLink": "http://devinit.org/#!/post/di-continues-role-as-technical-lead-for-iati",
-    "NewLink": ""
+    "NewLink": "https://devinit.org/how-we-work"
   },
   {
     "OldLink": "http://devinit.org/#!/post/interoperable-data-uganda",
-    "NewLink": ""
+    "NewLink": "https://devinit.org/resources/?types=&topic=&country=uganda&q="
   },
   {
     "OldLink": "http://devinit.org/#!/post/joined-up-data-alliance-announcement",
-    "NewLink": ""
+    "NewLink": "https://devinit.org/resources/joining-up-new-standards-in-a-disconnected-world/"
   },
   {
     "OldLink": "http://devinit.org/#!/post/key-trends-in-humanitarian-financing-what-do-they-mean-for-future-resourcing-to-address-crises-risk-and-vulnerability",
-    "NewLink": ""
+    "NewLink": "https://devinit.org/resources/?types=&topic=humanitarian-assistance_1&country=&q="
   },
   {
     "OldLink": "http://devinit.org/#!/post/launch-of-the-development-data-hub-in-uganda",
-    "NewLink": ""
+    "NewLink": "https://devinit.org/data"
   },
   {
     "OldLink": "http://devinit.org/#!/post/new-partnership-help-east-africans-access-use-understand-statistical-data-information",
-    "NewLink": ""
+    "NewLink": "https://devinit.org/what-we-do/where-we-work"
   },
   {
     "OldLink": "http://devinit.org/#!/post/unbundling-aid",
-    "NewLink": ""
+    "NewLink": "https://devinit.org/data"
   }
 ]


### PR DESCRIPTION
Still awaiting some additional links to put in the JSON, but tested on local:

```
$ docker-compose -f docker-compose.dev.yml exec web python3 manage.py fixlinks replace_links.json 
Replacing old link in page: p20-health-briefing
Replacing old link in page: p20-gender-briefing
Replacing old link in page: p20-nutrition
Replacing old link in page: p20-income-briefing
Replacing old link in page: p20-education-briefing
Replacing old link in page: p20-civil-registration-and-vital-statistics-briefing
Replacing old link in page: aid-spending-on-conflict-prevention-and-resolution-peace-and-security
Replacing old link in page: investments-to-end-poverty-2015
Done.
```