### PR TITLE
Fix | Footnotes

### DIFF
--- a/di_website/common/edit_handlers.py
+++ b/di_website/common/edit_handlers.py
@@ -62,5 +62,5 @@ def HelpPanel(
     wrapper_class='help-block help-info'
 ):
     """Define a help text panel."""
-    wrapped_content = '<div class="%s">%s</div>' % (wrapper_class, content)
+    wrapped_content = '<div class="%s"><svg class="icon icon-help" aria-hidden="true"><use href="#icon-help"></use></svg>%s</div>' % (wrapper_class, content)
     return WagtailHelpPanel(content=wrapped_content, template=template, heading=heading, classname=classname)

--- a/di_website/common/mixins.py
+++ b/di_website/common/mixins.py
@@ -1,7 +1,9 @@
+from django.conf import settings
 from django.db import models
 
 from wagtail.models import Orderable
 from wagtail.fields import RichTextField, StreamField
+from wagtail.images.models import SourceImageIOError
 
 from di_website.common.blocks import BaseStreamBlock, SectionStreamBlock, TypesetStreamBlock, TypesetFootnoteStreamBlock
 from di_website.common.constants import RICHTEXT_FEATURES_NO_FOOTNOTES
@@ -29,6 +31,12 @@ class CustomMetadataPageMixin(MetadataPageMixin):
 
     def get_meta_twitter_card_type(self):
         return 'summary_large_image'
+
+    def get_meta_image_rendition(self):
+        try:
+            return super(CustomMetadataPageMixin, self).get_meta_image_rendition()
+        except SourceImageIOError:
+            return None
 
 
 class HeroMixin(CustomMetadataPageMixin, models.Model):

--- a/di_website/common/templatetags/string_utils.py
+++ b/di_website/common/templatetags/string_utils.py
@@ -3,15 +3,20 @@ import os
 import bleach
 import uuid
 import re
+import html
 
+from bleach.css_sanitizer import CSSSanitizer
 from urllib.parse import urlparse
 from urllib.parse import parse_qs
 
 from django import template
 from django.utils import formats
+from django.utils.encoding import punycode
 from django.utils.text import Truncator, slugify
-from django.utils.html import strip_tags
-from django.utils.safestring import mark_safe
+from django.utils.html import (
+    escape, strip_tags, smart_urlquote, word_split_re, simple_url_re, simple_url_2_re,
+    WRAPPING_PUNCTUATION, TRAILING_PUNCTUATION_CHARS)
+from django.utils.safestring import SafeData, mark_safe
 from django.template.base import VariableDoesNotExist
 
 from wagtail.rich_text import expand_db_html, RichText
@@ -73,6 +78,7 @@ ATTRS['table'] = ['id', 'summary', 'title']
 ATTRS['th'] = ['id', 'colspan', 'rowspan', 'width']
 ATTRS['td'] = ['id', 'colspan', 'rowspan']
 
+css_sanitizer = CSSSanitizer(allowed_css_properties=STYLES)
 
 @register.filter(name='wysiwyg_tags')
 def wysiwyg_tags(text):
@@ -80,7 +86,7 @@ def wysiwyg_tags(text):
         text,
         tags=WYSIWYG_LIST,
         attributes=ATTRS,
-        styles=STYLES,
+        css_sanitizer=css_sanitizer,
         strip=True,
         strip_comments=True
     )
@@ -233,3 +239,100 @@ def buzzsprout_container_id(buzzsprout_url):
         return container_ids[0]
     else:
         return ""
+
+
+@register.filter
+def markdownify_urls(text):
+    """
+    NB: This code is a modified version of the urlize method of django.utils.html
+
+    Convert any URLs in text into markdown links format.
+
+    Works on http://, https://, www. links, and also on links ending in one of
+    the original seven gTLDs (.com, .edu, .gov, .int, .mil, .net, and .org).
+    Links can have trailing punctuation (periods, commas, close-parens) and
+    leading punctuation (opening parens) and it'll still do the right thing.
+    """
+    safe_input = isinstance(text, SafeData)
+
+    def trim_punctuation(lead, middle, trail):
+        """
+        Trim trailing and wrapping punctuation from `middle`. Return the items
+        of the new state.
+        """
+        # Continue trimming until middle remains unchanged.
+        trimmed_something = True
+        while trimmed_something:
+            trimmed_something = False
+            # Trim wrapping punctuation.
+            for opening, closing in WRAPPING_PUNCTUATION:
+                if middle.startswith(opening):
+                    middle = middle[len(opening):]
+                    lead += opening
+                    trimmed_something = True
+                # Keep parentheses at the end only if they're balanced.
+                if (middle.endswith(closing) and
+                        middle.count(closing) == middle.count(opening) + 1):
+                    middle = middle[:-len(closing)]
+                    trail = closing + trail
+                    trimmed_something = True
+            # Trim trailing punctuation (after trimming wrapping punctuation,
+            # as encoded entities contain ';'). Unescape entities to avoid
+            # breaking them by removing ';'.
+            middle_unescaped = html.unescape(middle)
+            stripped = middle_unescaped.rstrip(TRAILING_PUNCTUATION_CHARS)
+            if middle_unescaped != stripped:
+                trail = middle[len(stripped):] + trail
+                middle = middle[:len(stripped) - len(middle_unescaped)]
+                trimmed_something = True
+        return lead, middle, trail
+
+    def is_email_simple(value):
+        """Return True if value looks like an email address."""
+        # An @ must be in the middle of the value.
+        if '@' not in value or value.startswith('@') or value.endswith('@'):
+            return False
+        try:
+            p1, p2 = value.split('@')
+        except ValueError:
+            # value contains more than one @.
+            return False
+        # Dot must be in p2 (e.g. example.com)
+        if '.' not in p2 or p2.startswith('.'):
+            return False
+        return True
+
+    words = word_split_re.split(str(text))
+    for i, word in enumerate(words):
+        if '.' in word or '@' in word or ':' in word:
+            # lead: Current punctuation trimmed from the beginning of the word.
+            # middle: Current state of the word.
+            # trail: Current punctuation trimmed from the end of the word.
+            lead, middle, trail = '', word, ''
+            # Deal with punctuation.
+            lead, middle, trail = trim_punctuation(lead, middle, trail)
+
+            # Make URL we want to point to.
+            url = None
+            if simple_url_re.match(middle):
+                url = smart_urlquote(html.unescape(middle))
+            elif simple_url_2_re.match(middle):
+                url = smart_urlquote('http://%s' % html.unescape(middle))
+            elif ':' not in middle and is_email_simple(middle):
+                local, domain = middle.rsplit('@', 1)
+                try:
+                    domain = punycode(domain)
+                except UnicodeError:
+                    continue
+                url = 'mailto:%s@%s' % (local, domain)
+
+            # Make link.
+            if url:
+                middle = '[%s](%s)' % (escape(url), middle)
+                words[i] = mark_safe('%s%s%s' % (lead, middle, trail))
+            else:
+                if safe_input:
+                    words[i] = mark_safe(word)
+        elif safe_input:
+            words[i] = mark_safe(word)
+    return ''.join(words)

--- a/di_website/common/templatetags/string_utils.py
+++ b/di_website/common/templatetags/string_utils.py
@@ -3,7 +3,6 @@ import os
 import bleach
 import uuid
 import re
-import html
 
 from bleach.css_sanitizer import CSSSanitizer
 from urllib.parse import urlparse
@@ -11,12 +10,9 @@ from urllib.parse import parse_qs
 
 from django import template
 from django.utils import formats
-from django.utils.encoding import punycode
 from django.utils.text import Truncator, slugify
-from django.utils.html import (
-    escape, strip_tags, smart_urlquote, word_split_re, simple_url_re, simple_url_2_re,
-    WRAPPING_PUNCTUATION, TRAILING_PUNCTUATION_CHARS)
-from django.utils.safestring import SafeData, mark_safe
+from django.utils.html import strip_tags
+from django.utils.safestring import mark_safe
 from django.template.base import VariableDoesNotExist
 
 from wagtail.rich_text import expand_db_html, RichText
@@ -239,100 +235,3 @@ def buzzsprout_container_id(buzzsprout_url):
         return container_ids[0]
     else:
         return ""
-
-
-@register.filter
-def markdownify_urls(text):
-    """
-    NB: This code is a modified version of the urlize method of django.utils.html
-
-    Convert any URLs in text into markdown links format.
-
-    Works on http://, https://, www. links, and also on links ending in one of
-    the original seven gTLDs (.com, .edu, .gov, .int, .mil, .net, and .org).
-    Links can have trailing punctuation (periods, commas, close-parens) and
-    leading punctuation (opening parens) and it'll still do the right thing.
-    """
-    safe_input = isinstance(text, SafeData)
-
-    def trim_punctuation(lead, middle, trail):
-        """
-        Trim trailing and wrapping punctuation from `middle`. Return the items
-        of the new state.
-        """
-        # Continue trimming until middle remains unchanged.
-        trimmed_something = True
-        while trimmed_something:
-            trimmed_something = False
-            # Trim wrapping punctuation.
-            for opening, closing in WRAPPING_PUNCTUATION:
-                if middle.startswith(opening):
-                    middle = middle[len(opening):]
-                    lead += opening
-                    trimmed_something = True
-                # Keep parentheses at the end only if they're balanced.
-                if (middle.endswith(closing) and
-                        middle.count(closing) == middle.count(opening) + 1):
-                    middle = middle[:-len(closing)]
-                    trail = closing + trail
-                    trimmed_something = True
-            # Trim trailing punctuation (after trimming wrapping punctuation,
-            # as encoded entities contain ';'). Unescape entities to avoid
-            # breaking them by removing ';'.
-            middle_unescaped = html.unescape(middle)
-            stripped = middle_unescaped.rstrip(TRAILING_PUNCTUATION_CHARS)
-            if middle_unescaped != stripped:
-                trail = middle[len(stripped):] + trail
-                middle = middle[:len(stripped) - len(middle_unescaped)]
-                trimmed_something = True
-        return lead, middle, trail
-
-    def is_email_simple(value):
-        """Return True if value looks like an email address."""
-        # An @ must be in the middle of the value.
-        if '@' not in value or value.startswith('@') or value.endswith('@'):
-            return False
-        try:
-            p1, p2 = value.split('@')
-        except ValueError:
-            # value contains more than one @.
-            return False
-        # Dot must be in p2 (e.g. example.com)
-        if '.' not in p2 or p2.startswith('.'):
-            return False
-        return True
-
-    words = word_split_re.split(str(text))
-    for i, word in enumerate(words):
-        if '.' in word or '@' in word or ':' in word:
-            # lead: Current punctuation trimmed from the beginning of the word.
-            # middle: Current state of the word.
-            # trail: Current punctuation trimmed from the end of the word.
-            lead, middle, trail = '', word, ''
-            # Deal with punctuation.
-            lead, middle, trail = trim_punctuation(lead, middle, trail)
-
-            # Make URL we want to point to.
-            url = None
-            if simple_url_re.match(middle):
-                url = smart_urlquote(html.unescape(middle))
-            elif simple_url_2_re.match(middle):
-                url = smart_urlquote('http://%s' % html.unescape(middle))
-            elif ':' not in middle and is_email_simple(middle):
-                local, domain = middle.rsplit('@', 1)
-                try:
-                    domain = punycode(domain)
-                except UnicodeError:
-                    continue
-                url = 'mailto:%s@%s' % (local, domain)
-
-            # Make link.
-            if url:
-                middle = '[%s](%s)' % (escape(url), middle)
-                words[i] = mark_safe('%s%s%s' % (lead, middle, trail))
-            else:
-                if safe_input:
-                    words[i] = mark_safe(word)
-        elif safe_input:
-            words[i] = mark_safe(word)
-    return ''.join(words)

--- a/di_website/footnotes/forms.py
+++ b/di_website/footnotes/forms.py
@@ -1,14 +1,10 @@
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 
-from wagtail.admin.rich_text import DraftailRichTextArea
-
-from di_website.common.constants import SIMPLE_RICHTEXT_FEATURES
-
 
 class FootnoteForm(forms.Form):
     text = forms.CharField(
-        widget=DraftailRichTextArea(features=SIMPLE_RICHTEXT_FEATURES),
+        widget=forms.Textarea,
         label=_('Text')
     )
     uuid = forms.CharField(

--- a/di_website/publications/wagtail_hooks.py
+++ b/di_website/publications/wagtail_hooks.py
@@ -2,6 +2,7 @@ import json
 
 from django.conf import settings
 from django.template import loader
+from django.templatetags.static import static
 from django.utils.html import escape, format_html, format_html_join
 from django.utils.safestring import mark_safe
 
@@ -78,79 +79,8 @@ def register_welcome_panel(request, panels):
 @hooks.register('insert_editor_css')
 def editor_css():
 
-    # For the data-text selector, see https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/
-    # This fixes long URLs breaking the interface
-    # Any extra CSS for customising the admin interface can be added here as well
-    return format_html(
-        """
-        <style>
-
-            body.page-editor.model-personpage button.action-preview {{
-                display: none;
-            }}
-
-            .model_choice_field.radio_select label,
-            .model_multiple_choice_field.radio_select label,
-            .model_multiple_choice_field.checkbox_select_multiple label,
-            #id_display_state label {{
-                display: block;
-                float: none;
-                width: 100%;
-            }}
-
-            .page-editor .multiple .field-col,
-            .page-editor .multiple .field-content,
-            .page-editor .sequence-container .field-col,
-            .page-editor .sequence-container .field-content
-            {{
-                float: none;
-            }}
-
-            .page-editor .multiple label,
-            .page-editor .sequence-container label,
-            .page-editor .custom__itemlist .sequence-container
-            {{
-                width: 100%;
-            }}
-
-            .page-editor .sequence-container .stream-menu-inner ul
-            {{
-                text-align: center;
-            }}
-
-            .page-editor .sequence-container .stream-menu-inner ul li
-            {{
-                display: inline-block;
-                float: none;
-            }}
-
-            .page-editor .sequence-container .stream-menu li {{
-                width: auto;
-            }}
-
-            .page-editor .sequence-container [data-text="true"] {{
-                overflow-wrap: break-word;
-                word-wrap: break-word;
-                -ms-word-break: break-all;
-                word-break: break-all;
-                word-break: break-word;
-                -ms-hyphens: auto;
-                -moz-hyphens: auto;
-                -webkit-hyphens: auto;
-                hyphens: auto;
-            }}
-
-            .button-block .fields {{
-                border-bottom: 1px solid #e6e6e6;
-            }}
-
-            .indent-fields .fields {{
-                margin-left: 5%;
-            }}
-
-        </style>
-        """
-    )
+    # Any extra CSS for customising the page editor can be added here as well
+    return format_html('<link rel="stylesheet" href="{}">', static("css/editor.css"))
 
 
 @hooks.register('construct_whitelister_element_rules')

--- a/di_website/settings/base.py
+++ b/di_website/settings/base.py
@@ -84,6 +84,7 @@ INSTALLED_APPS = [
     'widget_tweaks',
     'wagtailmetadata',
     'django_google_optimize',
+    'markdownify.apps.MarkdownifyConfig',
 
     'django.contrib.sitemaps',
     'django.contrib.admin',

--- a/di_website/static/css/editor.css
+++ b/di_website/static/css/editor.css
@@ -1,0 +1,3 @@
+.footnote-form {
+  margin-top: 1rem;
+}

--- a/di_website/templates/publications/block_forms/custom_struct.html
+++ b/di_website/templates/publications/block_forms/custom_struct.html
@@ -3,6 +3,7 @@
     <h2>{{ block_definition.meta.label }}</h2>
     {% if help_text %}
         <div class="help-block help-info">
+            <svg class="icon icon-help" aria-hidden="true"><use href="#icon-help"></use></svg>
             <p>{{ help_text|safe }}</p>
         </div>
     {% endif %}

--- a/di_website/templates/publications/footnotes.html
+++ b/di_website/templates/publications/footnotes.html
@@ -10,7 +10,7 @@
                 <li class="footnotes__item">
                   <span class="heading type-m type-m--trailer footnotes__sub">{{ forloop.counter }}</span>
                   <a id="{{ item.footnote_id }}"></a>
-                  <div class="footnotes__text">{{ item.text | markdownify_urls | markdownify }}</div>
+                  <div class="footnotes__text">{{ item.text | markdownify }}</div>
 
                   {% section_id forloop.counter|stringformat:"i" page.chapter_number|default_if_none:1 as section_id %}
                   <a class="footnotes__return" href="#{{ item.source_id }}">Return to source text</a>

--- a/di_website/templates/publications/footnotes.html
+++ b/di_website/templates/publications/footnotes.html
@@ -1,4 +1,4 @@
-{% load string_utils wagtailcore_tags %}
+{% load string_utils wagtailcore_tags markdownify %}
 {% uid_url page as short_url %}
 {% if page.footnotes_list %}
   <section class="section section--alt">
@@ -10,8 +10,7 @@
                 <li class="footnotes__item">
                   <span class="heading type-m type-m--trailer footnotes__sub">{{ forloop.counter }}</span>
                   <a id="{{ item.footnote_id }}"></a>
-                  {% comment %} FIXME: implement a better way of checking for richtext than data-block-key {% endcomment %}
-                  <div class="footnotes__text">{% if 'data-block-key' in item.text %}{{ item.text | content }}{% else %}{{ item.text | urlize }}{% endif %}</div>
+                  <div class="footnotes__text">{{ item.text | markdownify_urls | markdownify }}</div>
 
                   {% section_id forloop.counter|stringformat:"i" page.chapter_number|default_if_none:1 as section_id %}
                   <a class="footnotes__return" href="#{{ item.source_id }}">Return to source text</a>

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ psycopg2==2.9.3
 gunicorn==20.1.0
 django-dotenv==1.4.2
 django-google-optimize==0.3.0
+django-markdownify>=0.9.2,<1.0
 codecov==2.0.16
 coverage==4.5.3
 wagtailfontawesome>=1.2.1,<1.3
@@ -12,7 +13,7 @@ django-widget-tweaks==1.4.5
 python-decouple==3.1
 num2words==0.5.10
 beautifulsoup4==4.8
-bleach==3.3.0
+bleach==5.0.1
 elasticsearch>=7.0.0,<7.16.3
 wagtail-linkchecker==0.6.0
 celery==4.4.7


### PR DESCRIPTION
Ticket #1199 

Our original footnotes implementation doesn't work when run through docker because for some reason, the Draftail Editor doesn't like add-ons that use it - it's a self-reference thing. Anyway, I thought we may need to abandon it completely, calling it a Time vs Value thing, but then I remembered Markdown. Anyway, the requirements of the ticket can be met by using markdown syntax i.e. for a link `[Link](#)` should be turned to HTML as a link.
The `markdownify` filter preserves existing behaviour since it also does what `urlize` does.

Also removed some redundant CSS for the Wagtail 4 upgrade and added an exception handler for a `wagtail-metadata` error when creating image renditions. Lastly, the help icon was missing on help blocks since the Wagtail 4 upgrade ... fixed that too.