### PR TITLE
Fix appleboy/scp-action version to v0.1.4

### DIFF
--- a/.github/workflows/deploy_CI.yml
+++ b/.github/workflows/deploy_CI.yml
@@ -54,7 +54,7 @@ jobs:
           echo "DATA_SITE_URL=dev.devinit.org" >> $GITHUB_ENV
 
       - name: copy deploy file via ssh
-        uses: appleboy/scp-action@master
+        uses: appleboy/scp-action@v0.1.4
         env:
           HOST: ${{ env.HOST }}
           USERNAME: ${{ env.USERNAME }}


### PR DESCRIPTION
Master is broken at the moment (see [this](https://github.com/appleboy/ssh-action/issues/197) ticket), and using a version number is ultimately more secure. Dependabot shall update as needed.