### PR TITLE
Use publication_date as default for hero-home-blog

### DIFF
--- a/di_website/templates/includes/heroes/hero-home-blog.html
+++ b/di_website/templates/includes/heroes/hero-home-blog.html
@@ -4,7 +4,9 @@
 {% block content %}
   <ul class="hero__meta">
     <li class="hero__meta-item hero__meta-item--block">Blog Post</li>
-    {% if page.first_published_at %}
+    {% if page.publication_date %}
+      <li class="hero__meta-item">{{ page.publication_date|date:"j F Y" }}</li>
+    {% else %}
       <li class="hero__meta-item">{{ page.first_published_at|date:"j F Y" }}</li>
     {% endif %}
   </ul>


### PR DESCRIPTION
Issue raised by Simon on Slack. Blog pages shown on the home page hero are showing the wrong date.