### PR TITLE
Replace edge ngram tokenizer with ngram to prevent partial matches

### DIFF
--- a/di_website/settings/base.py
+++ b/di_website/settings/base.py
@@ -166,12 +166,6 @@ AUTH_PASSWORD_VALIDATORS = [
 
 if config('ELASTIC_SEARCH_URL', ''):
 
-    elastic_search_tokens = [
-        'letter',
-        'digit',
-        'symbol',
-    ]
-
     WAGTAILSEARCH_BACKENDS = {
         'default': {
             'BACKEND': 'wagtail.search.backends.elasticsearch7',
@@ -184,7 +178,7 @@ if config('ELASTIC_SEARCH_URL', ''):
                     'analysis': {
                         'analyzer': {
                             "default": {
-                                "tokenizer": "edgengram_tokenizer",
+                                "tokenizer": "standard_tokenizer",
                                 "filter": [ "stop_filter",  "lowercase_filter" ]
                             }
                         },
@@ -198,11 +192,8 @@ if config('ELASTIC_SEARCH_URL', ''):
                             }
                         },
                         'tokenizer': {
-                            'edgengram_tokenizer': {
-                                'type': 'edge_ngram',
-                                'min_gram': 3,
-                                'max_gram': 10,
-                                'token_chars': elastic_search_tokens
+                            'standard_tokenizer': {
+                                'type': 'standard'
                             }
                         },
                     },


### PR DESCRIPTION
Right now a search for "disability" matches "disbursement" because they both begin with "dis". https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-edgengram-tokenizer.html

```
For example, if the max_gram is 3 and search terms are truncated to three characters, the search term apple is shortened to app. This means searches for apple return any indexed terms matching app, such as apply, approximate and apple.
```

So I think we should swap this for standard tokenizer, to make behavior much more predictable: https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-tokenizer.html