### PR TITLE
Revert "Bump wagtail from 4.2.4 to 5.0.5 (#1351)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django>=3.2.10,<3.3
-wagtail==5.0.5
+wagtail==4.2.4
 dj-database-url>=1.0.0,<2.0
 psycopg2==2.9.3
 gunicorn==20.1.0


### PR DESCRIPTION
This reverts commit 3c114cbd8df532e672534ba28a740dfdd519e351.

The upgrade was causing bugs. We shall manually upgrade when we are ready.