### PR TITLE
Fix footnote bug 

### DIFF
--- a/src/plugins/footnotes.ts
+++ b/src/plugins/footnotes.ts
@@ -11,7 +11,22 @@ const toggleFootnoteVisibility = (show: boolean): void => {
 };
 
 export const handleFootnotes = function (): void {
-  const button = document.querySelector('.footnotes button');
+  const button = document.querySelector('.footnotes button') as HTMLElement;
+  const footnotes = document.querySelectorAll('a[id^="note-source"]');
+  footnotes.forEach((footnote) => {
+    const footnoteChild = footnote.firstChild as HTMLElement;
+    footnote.addEventListener('click', function (event) {
+      event.preventDefault();
+      const footnoteText: RegExpMatchArray = (footnoteChild.innerHTML as string)?.match(/\d+/) as RegExpMatchArray;
+      const footnoteNumber = parseInt(footnoteText[0]);
+      if (button && footnoteNumber > 5) {
+        button.click();
+        document.querySelector(footnote.getAttribute('href') as string)?.scrollIntoView();
+      } else {
+        document.querySelector(footnote.getAttribute('href') as string)?.scrollIntoView();
+      }
+    });
+  });
   if (button) {
     button.addEventListener('click', (event: Event) => {
       event.preventDefault();


### PR DESCRIPTION
The page was not scrolling to linked content for footnotes whose linked content is hidden by the Show more button
This has been deployed to staging , please test [here](https://dev.devinit.org/resources/global-humanitarian-assistance-report-2023/beyond-humanitarian-funding-addressing-cycles-of-crises/) 